### PR TITLE
Update mq-spring-app chart to support Jaeger toggle

### DIFF
--- a/chart/base/templates/deployment.yaml
+++ b/chart/base/templates/deployment.yaml
@@ -128,13 +128,15 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   key: APP_NAME
-                  name: {{ include "mq-spring-app.fullname" . }}              
+                  name: {{ include "mq-spring-app.fullname" . }}        
+            - name: OPENTRACING_JAEGER_ENABLED
+              value: {{ .Values.jaeger.enabled | quote }}
           envFrom:
             - configMapRef:
-                name: {{ default "jaeger-config" .Values.jaegerConfigName }}
+                name: {{ default "jaeger-config" .Values.jaeger.configName }}
                 optional: true
             - secretRef:
-                name: {{ default "jaeger-access" .Values.jaegerSecretName }}
+                name: {{ default "jaeger-access" .Values.jaeger.secretName }}
                 optional: true
             {{- if eq .Values.security true }}     
             - secretRef:

--- a/chart/base/templates/jaegerconfigmap.yaml
+++ b/chart/base/templates/jaegerconfigmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.jaegerConfigName }}
+  name: {{ .Values.jaeger.configName }}
 data:
-  JAEGER_ENDPOINT: {{ .Values.jaegerCollectorEndpoint }}
+  JAEGER_ENDPOINT: {{ .Values.jaeger.collectorEndpoint }}

--- a/chart/base/values.yaml
+++ b/chart/base/values.yaml
@@ -37,9 +37,11 @@ ingress:
 
 #  tlsSecretName: ""
 
-jaegerConfigName: jaeger-config
-jaegerSecretName: jaeger-access
-jaegerCollectorEndpoint: http://jaeger-all-in-one-inmemory-collector.openshift-operators.svc.cluster.local:14268/api/traces
+jaeger:
+  enabled: false
+  configName: jaeger-config
+  secretName: jaeger-access
+  collectorEndpoint: http://jaeger-all-in-one-inmemory-collector.openshift-operators.svc.cluster.local:14268/api/traces
 
 vcsInfo:
   repoUrl: ""

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
 
 opentracing:
   jaeger:
-    enabled: true
+    enabled: false
     enable-b3-propagation: true
     enable128-bit-traces: true
     log-spans: true


### PR DESCRIPTION
Signed-off-by: Rick Osowski <rosowski@gmail.com>

Jaeger is currently set to "always-on" by default and there is not an easy way to turn it off, based upon the way the application is consumed and rolled out through our pipeline. This update makes it easier to enable and disable Jaeger depending upon deployment characteristics, while also preventing users from getting their logs spammed with error messages about unknown collector hosts (https://ibmcase.slack.com/archives/C02CQ6M2D2R/p1630857956224000) when Jaeger is not deployed in the cluster.